### PR TITLE
Checksum change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 ##############################################################################
 # Copyright (c) 2013 CINECA (www.hpc.cineca.it)
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,168 +21,155 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.11 FATAL_ERROR)
+
+find_package(IRODS 4.2.8 EXACT REQUIRED CONFIG)
+include(RequireOutOfSourceBuild)
+
+set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
+set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(GNUInstallDirs)
+if (NOT DEFINED ENV{DEST_LIB_DIR})
+    set(ENV{DEST_LIB_DIR} "/${CMAKE_INSTALL_LIBDIR}")
+    #set(ENV{DEST_LIB_DIR} "/usr/lib64")
+    # Note: this may have to be lib64 on 64-bit platforms.
+endif()
+message("DEST_LIB_DIR is defined as $ENV{DEST_LIB_DIR}")
+message("CMAKE_INSTALL_LIBDIR is defined as ${CMAKE_INSTALL_LIBDIR}")
+message("CMAKE_INSTALL_FULL_LIBDIR is defined as ${CMAKE_INSTALL_FULL_LIBDIR}")
+
 project (iRODS_DSI C CXX)
+include(UseLibCXX)
 set(GENERIC_LIB_VERSION "1.8")
-set(IRODS_MIN_VERSION "4.2.0")
 
 ##### Check ENV variables ######
 if (DEFINED ENV{GLOBUS_LOCATION})
     message("GLOBUS_LOCATION is defined as $ENV{GLOBUS_LOCATION}")
 else()
-    message( FATAL_ERROR "GLOBUS_LOCATION is NOT defined, CMake will exit." )
+    set(ENV{GLOBUS_LOCATION} "/usr")
 endif()
 
-set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-if (DEFINED ENV{IRODS_PATH})
-    message("IRODS_PATH is defined as $ENV{IRODS_PATH}")
-    if ($ENV{IRODS_PATH} STREQUAL "/usr")
-        add_definitions(-DIRODS_HEADER_HPP)
-        set(irods_include_path_list "$ENV{IRODS_PATH}/include/irods")
-        if (DEFINED ENV{IRODS_42_COMPAT})
-            #find_package(IRODS ${IRODS_MIN_VERSION} REQUIRED CONFIG)
-            find_package(IRODS REQUIRED CONFIG)
+##### iRODS #####
+set(IRODS_PLUGIN_REVISION "0")
 
-            set(CMAKE_INSTALL_RPATH $ENV{IRODS_EXTERNALS_PATH}/clang-runtime6.0-0/lib)
-            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
-            set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++")
-            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
-            add_compile_options(-nostdinc++ -O0)
+if (NOT IRODS_EXTERNALS_PACKAGE_ROOT)
+  set(IRODS_EXTERNALS_PACKAGE_ROOT "/opt/irods-externals" CACHE STRING "Choose the location of iRODS external packages." FORCE)
+  message(STATUS "Setting unspecified IRODS_EXTERNALS_PACKAGE_ROOT to '${IRODS_EXTERNALS_PACKAGE_ROOT}'. This is the correct setting for normal builds.")
+endif()
 
-            set(CMAKE_C_COMPILER $ENV{IRODS_EXTERNALS_PATH}/clang6.0-0/bin/clang)
-            set(CMAKE_CXX_COMPILER $ENV{IRODS_EXTERNALS_PATH}/clang6.0-0/bin/clang++)
-            link_libraries(c++abi)
-
-            remove_definitions(-DIRODS_HEADER_HPP)
-            add_definitions(-DIRODS_42)
-            if (DEFINED ENV{IRODS_EXTERNALS_PATH})
-                set(irods_include_path_list "$ENV{IRODS_PATH}/include/irods"
-                                    "$ENV{IRODS_EXTERNALS_PATH}/clang6.0-0/include/c++/v1")
-
-                set(irods_link_obj_path
-                    PRIVATE
-                    irods_client
-                    irods_plugin_dependencies
-                    irods_common
-                    "$ENV{IRODS_PATH}/lib/irods/plugins/network/libtcp_client.so"
-                    "$ENV{IRODS_PATH}/lib/irods/plugins/auth/libnative_client.so" 
-                    #"$ENV{IRODS_PATH}/lib/libirods_client.so"
-                    #"$ENV{IRODS_PATH}/lib/libirods_common.so"
-                    "-lrt"
-                    "-lcurl"
-                    "$ENV{IRODS_EXTERNALS_PATH}/avro1.9.0-0/lib/libavrocpp.so"
-                    "$ENV{IRODS_EXTERNALS_PATH}/jansson2.7-0/lib/libjansson.so"
-                    "$ENV{IRODS_EXTERNALS_PATH}/boost1.67.0-0/lib/libboost_filesystem.so"
-                    "$ENV{IRODS_EXTERNALS_PATH}/boost1.67.0-0/lib/libboost_regex.so"
-                    "$ENV{IRODS_EXTERNALS_PATH}/boost1.67.0-0/lib/libboost_system.so"
-                    "$ENV{IRODS_EXTERNALS_PATH}/boost1.67.0-0/lib/libboost_thread.so")
-            else()
-                message( FATAL_ERROR "IRODS_EXTERNALS_PATH is NOT defined, CMake will exit." )
-            endif()
-
-            if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
-                set(CPACK_PACKAGING_INSTALL_PREFIX "/" CACHE STRING "Package root path. \"/\" is correct for normal package builds.." FORCE)
-                message(STATUS "Setting unspecified CPACK_PACKAGING_INSTALL_PREFIX to '${CPACK_PACKAGING_INSTALL_PREFIX}'. This is the correct setting for normal builds.")
-            endif()
-            
-            if (NOT CPACK_DEBIAN_PACKAGE_VERSION)
-                set(CPACK_DEBIAN_PACKAGE_VERSION ${IRODS_CPACK_DEBIAN_PACKAGE_VERSION})
-            endif()
- 
-            set(CPACK_PACKAGE_FILE_NAME "irods-gridftp-client${IRODS_PACKAGE_FILE_NAME_SUFFIX}")
-            set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
-            set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
-            set(CPACK_COMPONENTS_GROUPING IGNORE)
-            set(CPACK_PACKAGE_VERSION ${IRODS_VERSION})
-            set(CPACK_PACKAGE_VERSION_MAJOR ${IRODS_VERSION_MAJOR})
-            set(CPACK_PACKAGE_VERSION_MINOR ${IRODS_VERSION_MINOR})
-            set(CPACK_PACKAGE_VERSION_PATCH ${IRODS_VERSION_PATCH})
-            set(CPACK_PACKAGE_CONTACT "Renaissance Computing Institute <info@irods.org>")
-            set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The integrated Rule-Oriented Data System")
-            set(CPACK_PACKAGE_VENDOR "Renaissance Computing Institute <info@irods.org>")
-            
-            set(CPACK_DEB_COMPONENT_INSTALL OFF)
-            set(CPACK_DEBIAN_PACKAGE_SECTION "contrib/science")
-            set(CPACK_DEBIAN_COMPRESSION_TYPE "gzip")
-            set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
-            set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://irods.org")
-            set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
-            set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION ON)
-            
-            set(CPACK_RPM_COMPONENT_INSTALL OFF)
-            set(CPACK_RPM_PACKAGE_RELEASE "1")
-            set(CPACK_RPM_PACKAGE_LICENSE "BSD-3-Clause")
-            set(CPACK_RPM_PACKAGE_VENDOR "iRODS Consortium")
-            set(CPACK_RPM_PACKAGE_URL "https://irods.org")
-            set(CPACK_RPM_PACKAGE_AUTOREQ 0)
-            set(CPACK_RPM_PACKAGE_AUTOPROV 0)
-            
-            set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
-            
-            set(CPACK_DEBIAN_PACKAGE_NAME "irods-gridftp-client")
-            set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${CPACK_DEBIAN_PACKAGE_VERSION}), libc6, libssl1.0.0")
-            #set(CPACK_DEBIAN_PACKAGE_REPLACES "irods-icat, irods-resource")
-            
-            set(CPACK_RPM_PACKAGE_NAME "irods-gridftp-client")
-            #set(CPACK_RPM_PACKAGE_OBSOLETES "irods-icat, irods-resource")
-            if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos linux")
-                set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, openssl")
-            elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
-                set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, libopenssl1_0_0")
-            endif()
-            
-            if (NOT CPACK_GENERATOR)
-              set(CPACK_GENERATOR ${IRODS_CPACK_GENERATOR} CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
-              message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
-            endif()
-            
-            include(CPack)
-
-        elseif (DEFINED ENV{IRODS_40_COMPAT})
-            set(irods_link_obj_path 
-                    "$ENV{IRODS_PATH}/lib/irods/libirods_client.so"
-                    "$ENV{IRODS_PATH}/lib/irods/libirods_client_api.so"
-                    "-lrt"
-                    "-lcurl"
-                    "-lpthread"
-                    "-pthread"
-                    "$ENV{IRODS_PATH}/lib/irods/libjansson.a"
-                    "$ENV{IRODS_PATH}/lib/irods/libboost_filesystem.a"
-                    "$ENV{IRODS_PATH}/lib/irods/libboost_regex.a"
-                    "$ENV{IRODS_PATH}/lib/irods/libboost_system.a"
-                    "$ENV{IRODS_PATH}/lib/irods/libboost_thread.a")
-        else()
-            set(irods_link_obj_path 
-                    "$ENV{IRODS_PATH}/lib/libirods_client.so"
-                    "$ENV{IRODS_PATH}/lib/libirods_client_api.so"
-                    "-lrt"
-                    "-lpthread"
-                    "-pthread"
-                    "-lssl"
-                    "-lcurl"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libjansson.a"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_chrono.a"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_filesystem.a"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_program_options.a"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_regex.a"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_system.a"
-                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_thread.a")
-        endif()
-    else()
-        set(irods_include_path_list "$ENV{IRODS_PATH}/lib/api/include"
-                "$ENV{IRODS_PATH}/lib/core/include"
-                "$ENV{IRODS_PATH}/server/icat/include"
-                "$ENV{IRODS_PATH}/lib/md5/include/"
-                "$ENV{IRODS_PATH}/lib/sha1/include/"
-                "$ENV{IRODS_PATH}/server/core/include/"
-                "$ENV{IRODS_PATH}/server/drivers/include/"
-                "$ENV{IRODS_PATH}/server/re/include/")
-        set(irods_link_obj_path "$ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a")
+macro(IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH DEPENDENCY_NAME DEPENDENCY_SUBDIRECTORY)
+  if (IS_DIRECTORY ${IRODS_EXTERNALS_FULLPATH_${DEPENDENCY_NAME}})
+    message(STATUS "Using user-specified value for IRODS_EXTERNALS_FULLPATH_${DEPENDENCY_NAME}: ${IRODS_EXTERNALS_FULLPATH_${DEPENDENCY_NAME}}")
+  else()
+    if (NOT IS_DIRECTORY ${IRODS_EXTERNALS_PACKAGE_ROOT}/${DEPENDENCY_SUBDIRECTORY})
+      message(FATAL_ERROR "${DEPENDENCY_NAME} not found at ${IRODS_EXTERNALS_PACKAGE_ROOT}/${DEPENDENCY_SUBDIRECTORY}")
     endif()
-else()
-    message( FATAL_ERROR "IRODS_PATH is NOT defined, CMake will exit." )
+    set(IRODS_EXTERNALS_FULLPATH_${DEPENDENCY_NAME} ${IRODS_EXTERNALS_PACKAGE_ROOT}/${DEPENDENCY_SUBDIRECTORY})
+  endif()
+endmacro()
+
+macro(IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST DEPENDENCY_NAME DEPENDENCY_SUBDIRECTORY)
+  IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH(${DEPENDENCY_NAME} ${DEPENDENCY_SUBDIRECTORY})
+  list(APPEND IRODS_PACKAGE_DEPENDENCIES_LIST irods-externals-${DEPENDENCY_SUBDIRECTORY})
+endmacro()
+string(REPLACE ";" ", " IRODS_PACKAGE_DEPENDENCIES_STRING "${IRODS_PACKAGE_DEPENDENCIES_LIST}")
+#################
+
+
+FIND_PACKAGE(CURL)
+IF(CURL_FOUND)
+    INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIR})
+    SET(requiredlibs ${requiredlibs} ${CURL_LIBRARIES} )
+ELSE(CURL_FOUND)
+    MESSAGE(FATAL_ERROR "Could not find the CURL library and development files.")
+ENDIF(CURL_FOUND)
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+add_definitions(-DIRODS_HEADER_HPP)
+
+add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter)
+
+remove_definitions(-DIRODS_HEADER_HPP)
+add_definitions(-DIRODS_42)
+set(irods_include_path_list
+    "${IRODS_INCLUDE_DIRS}"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
+    "${IRODS_EXTERNALS_FULLPATH_JSON}/include"
+    )
+
+set(irods_link_obj_path
+    PRIVATE
+    irods_client
+    irods_common
+    irods_plugin_dependencies
+    "-lrt"
+    "${IRODS_EXTERNALS_FULLPATH_AVRO}/lib/libavrocpp.so"
+    "${IRODS_EXTERNALS_PACKAGE_ROOT}/jansson2.7-0/lib/libjansson.so"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_thread.so"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so"
+    "/${IRODS_PLUGINS_DIRECTORY}/network/libtcp_client.so"
+    "/${IRODS_PLUGINS_DIRECTORY}/auth/libnative_client.so"
+    )
+
+if (NOT CPACK_DEBIAN_PACKAGE_VERSION)
+    set(CPACK_DEBIAN_PACKAGE_VERSION ${IRODS_CPACK_DEBIAN_PACKAGE_VERSION})
 endif()
+
+set(CPACK_PACKAGE_FILE_NAME "irods-gridftp-client${IRODS_PACKAGE_FILE_NAME_SUFFIX}")
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+set(CPACK_COMPONENTS_GROUPING IGNORE)
+set(CPACK_PACKAGE_VERSION ${IRODS_VERSION})
+set(CPACK_PACKAGE_VERSION_MAJOR ${IRODS_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${IRODS_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${IRODS_VERSION_PATCH})
+set(CPACK_PACKAGE_CONTACT "Renaissance Computing Institute <info@irods.org>")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The integrated Rule-Oriented Data System")
+set(CPACK_PACKAGE_VENDOR "Renaissance Computing Institute <info@irods.org>")
+
+set(CPACK_DEB_COMPONENT_INSTALL OFF)
+set(CPACK_DEBIAN_PACKAGE_SECTION "contrib/science")
+set(CPACK_DEBIAN_COMPRESSION_TYPE "gzip")
+set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://irods.org")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION ON)
+
+set(CPACK_RPM_COMPONENT_INSTALL OFF)
+set(CPACK_RPM_PACKAGE_RELEASE "1")
+set(CPACK_RPM_PACKAGE_LICENSE "BSD-3-Clause")
+set(CPACK_RPM_PACKAGE_VENDOR "iRODS Consortium")
+set(CPACK_RPM_PACKAGE_URL "https://irods.org")
+set(CPACK_RPM_PACKAGE_AUTOREQ 0)
+set(CPACK_RPM_PACKAGE_AUTOPROV 0)
+
+set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
+
+set(CPACK_DEBIAN_PACKAGE_NAME "irods-gridftp-client")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime (= ${CPACK_DEBIAN_PACKAGE_VERSION}), libc6, libssl1.0.0")
+#set(CPACK_DEBIAN_PACKAGE_REPLACES "irods-icat, irods-resource")
+
+set(CPACK_RPM_PACKAGE_NAME "irods-gridftp-client")
+#set(CPACK_RPM_PACKAGE_OBSOLETES "irods-icat, irods-resource")
+if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos linux")
+    set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, openssl")
+elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
+    set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, libopenssl1_0_0")
+endif()
+
+if (NOT CPACK_GENERATOR)
+  set(CPACK_GENERATOR ${IRODS_CPACK_GENERATOR} CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+  message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+endif()
+
+include(CPack)
+
 
 if (DEFINED ENV{RESOURCE_MAP_PATH})
     message("RESOURCE_MAP_PATH is defined as $ENV{RESOURCE_MAP_PATH}")
@@ -194,19 +181,12 @@ if (DEFINED ENV{FLAVOR})
     message("FLAVOR is defined as $ENV{FLAVOR}")
     set(dsi_library_name globus_gridftp_server_iRODS_$ENV{FLAVOR})
     set(gridmap_callout_library_name gridmap_iRODS_callout_$ENV{FLAVOR})
-    set(gridmap_callout_library_LINK_FLAGS "-lglobus_gridmap_callout_error_$ENV{FLAVOR}")
+    set(gridmap_callout_library_LINK_FLAGS "-lglobus_gridmap_callout_error")
 else()
-    message( WARNING "FLAVOR is NOT defined!" )
     set(dsi_library_name globus_gridftp_server_iRODS)
     set(gridmap_callout_library_name gridmap_iRODS_callout)
     set(gridmap_callout_library_LINK_FLAGS "-lglobus_gridmap_callout_error")
 endif()
-
-if (NOT DEFINED ENV{DEST_LIB_DIR})
-    set(ENV{DEST_LIB_DIR} "$ENV{GLOBUS_LOCATION}/lib")
-    # Note: this may have to be lib64 on 64-bit platforms.
-endif()
-message("DEST_LIB_DIR is defined as $ENV{DEST_LIB_DIR}")
 
 if (NOT DEFINED ENV{DEST_ETC_DIR})
     if ($ENV{GLOBUS_LOCATION} STREQUAL "/usr")
@@ -226,16 +206,16 @@ message("DEST_BIN_DIR is defined as $ENV{DEST_BIN_DIR}")
 message("DSI library name will be: ${dsi_library_name}")
 message("Gridmap callout library name will be: ${gridmap_callout_library_name}")
 
-add_library(${dsi_library_name} SHARED DSI/globus_gridftp_server_iRODS.c DSI/pid_manager.c external/cJSON.c)
+add_library(${dsi_library_name} SHARED DSI/globus_gridftp_server_iRODS.cpp DSI/pid_manager.c external/cJSON.c)
 add_library(${gridmap_callout_library_name} SHARED DSI/gridmap_iRODS_callout.c DSI/libirodsmap.c)
 
-set_target_properties(${dsi_library_name} PROPERTIES VERSION ${GENERIC_LIB_VERSION} )
+set_target_properties(${dsi_library_name} PROPERTIES VERSION ${GENERIC_LIB_VERSION})
 set_target_properties(${dsi_library_name} PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(${dsi_library_name} ${irods_link_obj_path})
+target_link_libraries(${dsi_library_name} ${irods_link_obj_path} ${CURL_LIBRARIES})
 
-set_target_properties(${gridmap_callout_library_name} PROPERTIES LINK_FLAGS ${gridmap_callout_library_LINK_FLAGS} VERSION ${GENERIC_LIB_VERSION} )
+set_target_properties(${gridmap_callout_library_name} PROPERTIES LINK_FLAGS ${gridmap_callout_library_LINK_FLAGS} VERSION ${GENERIC_LIB_VERSION})
 set_target_properties(${gridmap_callout_library_name} PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(${gridmap_callout_library_name} ${irods_link_obj_path})
+target_link_libraries(${gridmap_callout_library_name} ${irods_link_obj_path} ${CURL_LIBRARIES})
 
 set(gridmap_callout_conf_name gridmap_iRODS_callout.conf)
 
@@ -243,29 +223,30 @@ set(testirodsmap_exe "testirodsmap")
 set(testirodsmap_exe_LINK_FLAGS "-ldl -lglobus_gss_assist -lstdc++")
 add_executable(${testirodsmap_exe} DSI/testirodsmap.c DSI/libirodsmap.c)
 set_target_properties(${testirodsmap_exe} PROPERTIES LINKER_LANGUAGE CXX)
-set_target_propertieS(${testirodsmap_exe} PROPERTIES LINK_FLAGS ${testirodsmap_exe_LINK_FLAGS})
-target_link_libraries(${testirodsmap_exe} ${irods_link_obj_path})
+set_target_properties(${testirodsmap_exe} PROPERTIES LINK_FLAGS ${testirodsmap_exe_LINK_FLAGS})
+target_link_libraries(${testirodsmap_exe} ${irods_link_obj_path} ${CURL_LIBRARIES})
 
 set(testpidmanager_exe "testpidmanager")
 add_executable(${testpidmanager_exe} DSI/pid_manager_test.c DSI/pid_manager.c external/cJSON.c)
-target_link_libraries(${testpidmanager_exe} ${irods_link_obj_path} "-lm -lglobus_gridftp_server")
-
-set(CMAKE_C_FLAGS "-g -O2 -Wall -lstdc++ -lcurl -O3 -DNDEBUG")
+target_link_libraries(${testpidmanager_exe} ${irods_link_obj_path} "-lm -lglobus_gridftp_server" ${CURL_LIBRARIES})
 
 include_directories(${irods_include_path_list})
-include_directories($ENV{GLOBUS_LOCATION}/include/globus
+include_directories(
+        $ENV{GLOBUS_LOCATION}/include/globus
         $ENV{GLOBUS_LOCATION}/lib/globus/include
         $ENV{GLOBUS_LOCATION}/lib64/globus/include
+        ${CURL_INCLUDE_DIR}
         DSI
         external)
 if (DEFINED ENV{FLAVOR})
     include_directories($ENV{GLOBUS_LOCATION}/include/ENV{FLAVOR})
 endif()
 
+message(STATUS "PROJECT_BINARY_DIR is ${PROJECT_BINARY_DIR}")
+
 install(TARGETS ${dsi_library_name} ${gridmap_callout_library_name} DESTINATION $ENV{DEST_LIB_DIR})
 install(TARGETS ${testirodsmap_exe} DESTINATION $ENV{DEST_BIN_DIR})
 install(TARGETS ${testpidmanager_exe} DESTINATION $ENV{DEST_BIN_DIR})
 configure_file(DSI/${gridmap_callout_conf_name}.in ${gridmap_callout_conf_name})
-install(FILES ${gridmap_callout_conf_name} DESTINATION $ENV{DEST_ETC_DIR})
-
+install(FILES ${PROJECT_BINARY_DIR}/${gridmap_callout_conf_name} DESTINATION $ENV{DEST_ETC_DIR})
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,49 @@ B2STAGE-GridFTP (iRODS-DSI)
 
 B2STAGE service core code for EUDAT project: DSI interface for iRODS (version > 4)
 
-GridFTP is a high-performance, secure, reliable data transfer protocol which provides remote access to data stores. 
+GridFTP is a high-performance, secure, reliable data transfer protocol which provides remote access to data stores.
 There are many different types of data storage systems from standard file systems to arrays of magnetic tape: to allow GridFTP to be used with as many data storage systems as possible, the GridFTP can be extended, implementing an interface called Data Storage Interface (DSI).
 
 The GridFTP iRODS DSI consists of C functions which can interact with iRODS through the iRODS C API. The main supported operations are get, put, delete and list.
 
 ![Alt text](/images/iRODS-DSI.png?raw=true "iRODS-DSI")
 
-Once installed and configured, users will be able to interact with iRODS through 
+Once installed and configured, users will be able to interact with iRODS through
 any GridFTP client passing to it a valid iRODS path; for instance:
 ```
 $ globus-url-copy -list gsiftp://develvm.cluster.cineca.it:2811/tempZone/home/myuser/
 ```
- 
+
 will list the content of the */tempZone/home/myuser/* iRODS collection.
 
 The module can be loaded by the GridFTP server at start-up time through a specific command line option. Therefore, no changes are required in the GridFTP server installation. The decoupling from the possible future changes to the server simplifies the maintenance of the software module.
+
+Install From Pre-Build Packages
+===============
+
+The Globus plugin for iRODS can be installed from pre-built packages.
+
+- First, the iRODS repos need to be installed into your package manager.  See the instructions at https://packages.irods.org/ to do this.
+
+- Install the packages as follows:
+
+	Ubuntu:
+
+	```
+	sudo apt-get install irods-gridftp-client
+	```
+
+	Centos:
+	```
+	sudo yum -y install irods-gridftp-client
+	```
+
+- The pre-built packages install the lib files in /usr/lib, the configuration file in /etc/grid-security, and the test binary programs in /usr/bin.
+
+
+
+Building the Plugin and Installing in Custom Location
+===============
 
 Prerequisites
 --------------------------------
@@ -73,21 +100,19 @@ Building iRODS DSI with CMake
 	```
 	git clone https://github.com/EUDAT-B2STAGE/B2STAGE-GridFTP.git
 	```
-    
+
 2. Create a deployment folder:
 	```
-	mkdir /<preferred_path>/iRODS_DSI
+	mkdir /<preferred_path>
 	```
- 
+
 3. Set some environment variables that are used by the build process and the PATH so that the correct version of cmake will be found.
 	```
-	export PATH=/opt/irods-externals/cmake3.5.2-0/bin:$PATH
+	export PATH=/opt/irods-externals/cmake3.11.4-0/bin:$PATH
 	export GLOBUS_LOCATION="/usr"
-	export IRODS_PATH="/usr"
-	export DEST_LIB_DIR="/<preferred_path>/iRODS_DSI"
-	export DEST_BIN_DIR="/<preferred_path>/iRODS_DSI"
-	export DEST_ETC_DIR="/<preferred_path>/iRODS_DSI"
-	export IRODS_EXTERNALS_PATH=/opt/irods-externals
+	export DEST_LIB_DIR="/<preferred_path>"
+	export DEST_BIN_DIR="/<preferred_path>"
+	export DEST_ETC_DIR="/<preferred_path>"
 	```
 	In Ubuntu you may need to set up C_INCLUDE_PATH so that the globus_config.h header can be found.
 	```
@@ -96,11 +121,6 @@ Building iRODS DSI with CMake
 	or
 	```
 	export C_INCLUDE_PATH=/usr/include/globus
-	```
-
-	If you are building for iRODS 4.2, set the IRODS_42_COMPAT environment variable to true.
-	```
-	export IRODS_42_COMPAT=true
 	```
 
 4. Build and install the iRODS-DSI:
@@ -112,12 +132,12 @@ Building iRODS DSI with CMake
 
 
 Configuring the GridFTP server and run
---------------------------------
+===============
 
 1. As the user who runs the GridFTP server, create the file *~/.irods/irods_environment.json* (or *~/.irods/.irodsEnv* for iRODS < 4.1.x) and populate it with the information related to a rodsadmin" user; for instance:
 	```
 	{
-	   "irods_host" : "irods4", 
+	   "irods_host" : "irods4",
 	   "irods_port" : 1247,
 	   "irods_user_name" : "rods",
 	   "irods_zone_name" : "tempZone",
@@ -126,13 +146,21 @@ Configuring the GridFTP server and run
 	```
 	Note that the *"irods_host"* and *"irods_port"* identify the iRODS server that the DSI will contact during each request. Be sure to set the *irods_default_resource*, this variable is not set when you create the file with *iinit* or when you copy it over from another user.
 
-2. As the user who runs the GridFTP server, try an `ils` icommand to verify that the information set in the *irods_environment.json* are fine. If needed, perform an `iinit` to authenticate the iRODS user. 
+2. As the user who runs the GridFTP server, try an `ils` icommand to verify that the information set in the *irods_environment.json* are fine. If needed, perform an `iinit` to authenticate the iRODS user.
 
-3. Add the following lines to the GridFTP configuration file (typically $GLOBUS_LOCATION/etc/gridftp.conf*):
+3. Update the gridftp.conf file, typically in *$GLOBUS_LOCATION/etc/gridftp.conf*.
+
+- If the plugin was installed via pre-built packages:
 	```
-	$LD_LIBRARY_PATH "$LD_LIBRARY_PATH:/<preferred_path>/iRODS_DSI"
 	$irodsConnectAsAdmin "rods"
-	load_dsi_module iRODS 
+	load_dsi_module iRODS
+	auth_level 4
+	```
+- If the plugin was built and the user set DEST_LIB_DIR to /<preferred_path>
+	```
+	$LD_LIBRARY_PATH "$LD_LIBRARY_PATH:/<preferred_path>"
+	$irodsConnectAsAdmin "rods"
+	load_dsi_module iRODS
 	auth_level 4
 	```
 	In case the GridFTP is run as a system service, also set the $HOME env variable pointing to the home folder of the user who runs the gridftp server:
@@ -140,28 +168,23 @@ Configuring the GridFTP server and run
 	$HOME /path/to/user/home
 	```
 
-4. Add the following line at the beginning of the *globus-gridftp-server* (usually */etc/init.d/globus-gridftp-server*) file:
+4. If the plugin was built and the user set the DEST_LIB_DIR to /<preferred_path>, add the following line at the beginning of the *globus-gridftp-server* (usually */etc/init.d/globus-gridftp-server*) file. (This is not required if installing from pre-built packages.)
 	```
-	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/<preferred_path>/iRODS_DSI/"
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/<preferred_path>/"
 	```
 
 5. When deploying the DSI with iRODS 4.1, it is necessary to load the GridFTP server library alongside the DSI library by adding the following lines at the beginning of the *globus-gridftp-server*  (usually */etc/init.d/globus-gridftp-server*) file:
 	Ubuntu:
 	```
-	export LD_PRELOAD="$LD_PRELOAD:/usr/lib/x86_64-linux-gnu/libglobus_gridftp_server.so:/iRODS_DSI/libglobus_gridftp_server_iRODS.so"
+	export LD_PRELOAD="$LD_PRELOAD:/usr/lib/x86_64-linux-gnu/libglobus_gridftp_server.so:/libglobus_gridftp_server_iRODS.so"
 	```
 
 	Centos:
 	```
-	export LD_PRELOAD="$LD_PRELOAD:/usr/lib64/libglobus_gridftp_server.so:/iRODS_DSI/libglobus_gridftp_server_iRODS.so"
-	```
-     
-6. To enable the GridFTP CKSM (checksum) command to interoperate with Globus.org, it is necessary to configure iRODS to use MD5 checksums (iRODS 4 otherwise defaults to SHA-256). Edit */etc/irods/server_config.json* and set:
-	```
-	"default_hash_scheme": "MD5",
+	export LD_PRELOAD="$LD_PRELOAD:/usr/lib64/libglobus_gridftp_server.so:/libglobus_gridftp_server_iRODS.so"
 	```
 
-7. Run the server with:
+6. Run the server with:
 	```
 	/etc/init.d/globus-gridftp-server restart
 	```
@@ -171,7 +194,7 @@ Additional configuration
 --------------------------------
 
 1. Optionally, it is possible to enable the DSI module to manage the input path as a PID: the DSI will try to resolve the PID and perform the requested operation using the URI returned by the Handle server (currently only listing and downloading is supported).
-	For instance: 
+	For instance:
 	```
 	globus-url-copy -list  gsiftp://develvm01.pico.cineca.it:2811/11100/da3dae0a-6371-11e5-ba64-a41f13eb32b2/
 	```
@@ -191,7 +214,7 @@ Additional configuration
 
 	Note: Once the PID is correctly resolved, the requested operation (listing or downloading) will be correctly performed only if the URI returned by the Handle server is a valid iRODS path pointing to the iRODS instance to which the DSI is connected to.
 
-2. If desired, change the default home directory by setting the homeDirPattern environment variable in  
+2. If desired, change the default home directory by setting the homeDirPattern environment variable in
 	```
 	$GLOBUS_LOCATION/etc/gridftp.conf
 	```
@@ -206,7 +229,7 @@ Additional configuration
 	```
 	$homeDirPattern "/%s/home"
 	```
-        
+
 3. It is possible to specify a policy to manage more than one iRODS resource setting the irodsResourceMap environment variable in `$GLOBUS_LOCATION/etc/gridftp.conf`.
 	```
 	$irodsResourceMap "path/to/mapResourcefile"
@@ -220,16 +243,16 @@ Additional configuration
 	/CINECA01/home/cin_staff/rmucci00;resc-repl
 	/CINECA01/home/cin_staff/mrossi;resc-repl
 	```
-	If none of the listed paths is matched, the iRODS default resource is used. 
+	If none of the listed paths is matched, the iRODS default resource is used.
 
-4. Optionally, use a Globus gridmap callout module to map subject DNs to iRODS user names based on the existing mappings in iRODS (in r_user_auth table). 
+4. Optionally, use a Globus gridmap callout module to map subject DNs to iRODS user names based on the existing mappings in iRODS (in r_user_auth table).
 	Configuring this feature eliminates the need for a local grid map file - all user mappings can be done through the callout function.
 
-	The gridmap callout configuration file gets already created as '/preferred_path/iRODS_DSI/gridmap_iRODS_callout.conf'.
+	The gridmap callout configuration file gets already created as '/preferred_path/gridmap_iRODS_callout.conf'.
 
-	To activate the module, set the '$GSI_AUTHZ_CONF' environment variable in `$GLOBUS_LOCATION/etc/gridftp.conf` to point to the configuration file already created as '/preferred_path/iRODS_DSI/gridmap_iRODS_callout.conf'.
+	To activate the module, set the '$GSI_AUTHZ_CONF' environment variable in `$GLOBUS_LOCATION/etc/gridftp.conf` to point to the configuration file already created as '/preferred_path/gridmap_iRODS_callout.conf'.
 	```
-	$GSI_AUTHZ_CONF /preferred_path/iRODS_DSI/gridmap_iRODS_callout.conf
+	$GSI_AUTHZ_CONF /preferred_path/gridmap_iRODS_callout.conf
 	```
 	Note that in order for this module to work, the server certificate DN must be authorized to connect as a rodsAdmin user (e.g., the 'rods' user).
 
@@ -238,18 +261,18 @@ Additional notes
 ---------------------------------
 
 This module also supports invoking an iRODS server-side command with iexec in case the DN does not have a mapping yet. The command would receive the DN being mapped as a single argument and may for example add a mapping to an existing account, or create a new account.
-To enable this feature, set the `$irodsDnCommand` environment variable in '/etc/gridftp.conf' to the name of the command to execute. On the iRODS server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'. 
+To enable this feature, set the `$irodsDnCommand` environment variable in '/etc/gridftp.conf' to the name of the command to execute. On the iRODS server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.
 For example, to invoke a script called 'createUser', add:
 ```
 $irodsDnCommand "createUser"
 ```
 
-There is also a command line utility to test the mapping lookups (and script execution) that would otherwise be done by the gridmap module. This utility command gets installed into '$DEST_BIN_DIR/testirodsmap' and should be invoked with the DN as a single argument. 
-The command would need to see the same environment variables as the gridmap module loaded into the GridFTP server - specifically, `$irodsEnvFile` pointing to the iRODS environment and '$irodsDnCommand' setting the command to invoke if no mapping is found. The 'testirodsmap' command also needs to have access to the server host certificate - and find it either through the default mechanisms used by Globus GSI or by explicitly setting the 
+There is also a command line utility to test the mapping lookups (and script execution) that would otherwise be done by the gridmap module. This utility command gets installed into '$DEST_BIN_DIR/testirodsmap' and should be invoked with the DN as a single argument.
+The command would need to see the same environment variables as the gridmap module loaded into the GridFTP server - specifically, `$irodsEnvFile` pointing to the iRODS environment and '$irodsDnCommand' setting the command to invoke if no mapping is found. The 'testirodsmap' command also needs to have access to the server host certificate - and find it either through the default mechanisms used by Globus GSI or by explicitly setting the
 'X509_USER_CERT' and 'X509_USER_KEY' environment variables.
 (The easiest way is to run the command in the same environment as the Globus GridFTP server, i.e., under the root account). For example, invoke the command with:
 ```
-export irodsDnCommand=createUser 
+export irodsDnCommand=createUser
 export irodsEnvFile=/path/to/.irodsEnv
 $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 ```
@@ -258,18 +281,18 @@ $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 Licence
 ---------------------------------
 Copyright 2011-2017 EUDAT CDI - www.eudat.eu.
- 
-Copyright (c) 1999-2006 University of Chicago
-  
 
- 
+Copyright (c) 1999-2006 University of Chicago
+
+
+
  Globus DSI to manage data on iRODS.
- 
+
  Author: Roberto Mucci - SCAI - CINECA
  Email:  hpc-service@cineca.it
 
  Globus gridmap iRODS callout to map subject DNs to iRODS accounts.
- 
+
  Author: Vladimir Mencl, University of Canterbury
  Email:  vladimir.mencl@canterbury.ac.n
 


### PR DESCRIPTION
Changes for how we pass checksums/hashes to Globus.

- So that we can support client requested hashes, the iRODS hash mechanism is no longer being used.
- The hashes are calculated on the client side and saved as metadata to the objects.  Subsequent requests for the same algorithm will simply return the value in metadata.  If the file is updated since the checksum has been calculated, a new checksum will be calculated and metadata will be updated.
- All checksums are presented in hex.  Base64 is converted to hex on the client side when necessary.
- Added new checksum algorithms - sha-512, adler-32, and sha-1.