### PR TITLE
must have BLOCKING descriptor set when blocking during long operations

### DIFF
--- a/DSI/globus_gridftp_server_iRODS.cpp
+++ b/DSI/globus_gridftp_server_iRODS.cpp
@@ -2216,8 +2216,8 @@ globus_l_gfs_iRODS_deactivate(void);
  */
 static globus_gfs_storage_iface_t       globus_l_gfs_iRODS_dsi_iface =
 {
-    //0,//GLOBUS_GFS_DSI_DESCRIPTOR_BLOCKING | GLOBUS_GFS_DSI_DESCRIPTOR_SENDER,
-    GLOBUS_GFS_DSI_DESCRIPTOR_HAS_REALPATH,  // descriptor
+    GLOBUS_GFS_DSI_DESCRIPTOR_BLOCKING | GLOBUS_GFS_DSI_DESCRIPTOR_SENDER |
+      GLOBUS_GFS_DSI_DESCRIPTOR_HAS_REALPATH,  // descriptor
     globus_l_gfs_iRODS_start,
     globus_l_gfs_iRODS_destroy,
     nullptr, /* list */


### PR DESCRIPTION
- fixes large file checksum timeouts
- without BLOCKING set, the intermediate checksum markers are not processed until the dsi returns
SENDER is also correct, but missing that doesn't cause any issues