### PR TITLE
4.2.11 fixes

### DIFF
--- a/DSI/globus_gridftp_server_iRODS.cpp
+++ b/DSI/globus_gridftp_server_iRODS.cpp
@@ -824,7 +824,7 @@ globus_l_gfs_iRODS_start(
     load_client_api_plugins();
 
     globus_l_gfs_iRODS_handle_t *       iRODS_handle;
-    globus_result_t                     result;
+    globus_result_t                     result = GLOBUS_SUCCESS;
     globus_gfs_finished_info_t          finished_info;
 
     rodsEnv myRodsEnv;
@@ -1037,7 +1037,7 @@ globus_l_gfs_iRODS_stat(
     globus_l_gfs_iRODS_handle_t *       iRODS_handle;
     char *                              handle_server;
     char *                              URL;
-    globus_result_t                     result;
+    globus_result_t                     result = GLOBUS_SUCCESS;
 
     GlobusGFSName(globus_l_gfs_iRODS_stat);
     globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: %s called\n", __FUNCTION__);
@@ -2674,7 +2674,7 @@ globus_l_gfs_iRODS_read_from_net(
     globus_l_gfs_iRODS_handle_t *         iRODS_handle)
 {
     globus_byte_t *                     buffer;
-    globus_result_t                     result;
+    globus_result_t                     result = GLOBUS_SUCCESS;
     GlobusGFSName(globus_l_gfs_iRODS_read_from_net);
 
     irods::at_scope_exit cleanup_and_finalize{[&iRODS_handle, &result] {

--- a/DSI/globus_gridftp_server_iRODS.cpp
+++ b/DSI/globus_gridftp_server_iRODS.cpp
@@ -1304,7 +1304,6 @@ void *send_cksum_updates(void *args)
     while (true) {
 
         pthread_mutex_lock(cksum_args->mutex);
-        irods::at_scope_exit unlock_mutex{[&cksum_args] { pthread_mutex_unlock(cksum_args->mutex); }};
 
         bool break_out = *cksum_args->done_flag;
 
@@ -1318,6 +1317,8 @@ void *send_cksum_updates(void *args)
             globus_gridftp_server_intermediate_command(*cksum_args->op, GLOBUS_SUCCESS, size_t_str);
             last_update_time = time(0);
         }
+
+        pthread_mutex_unlock(cksum_args->mutex);
 
         if (break_out) {
             break;


### PR DESCRIPTION
- Fixes missing initialization on some exit guard parameters which can result in crashes if globus_gridftp_server_finished* gets called multiple times.  I saw a consistent crash in listings/stat()

- The checksum updates thread was locked around sleep(1) which limited progress.

- After reviewing above, saw that sleep(1) in the checksum updates thread puts a floor of 1s on any checksum calculation that wasn't immediately ready.  Using pthread_cond_timedwait() allows ending that thread as soon as possible.  Will improve checksum performance on transfers with many small files.