### PR TITLE
[108] Updated cpu limit to be string

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         deploy:
             resources:
                 limits:
-                    cpus: 1
+                    cpus: '1'
                     memory: 8G 
     globus-ubuntu22:
         build:


### PR DESCRIPTION
This was just a required change needed after upgrading docker-compose version.