### PR TITLE
4 3 4 update

### DIFF
--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -37,11 +37,3 @@ After this is done, make the changes to the following files to use these built p
 3. Uncomment the installation line in the `install_local_irods_client_packages_<os>.sh` files for the platforms that are to be tested. Update the version number in the deb and rpm package filenames as necessary.
 4. Update `irods.ubuntu22.Dockerfile` and comment out the line that installs the iRODS packages from the iRODS repo.
 5. Update `start.irods.ubuntu22.sh` and uncomment the line that installs the locally built iRODS packages.  Update version number as necessary.
- 
-
-Test Limitations
-----------------
-
-Currently this only runs against a Globus server running Ubuntu 22.  This will be expanded in the future.
-
-The `python run_all_tests.py` command can be run against Globus installations in other operating systems but those will need to be set up manually.  Refer to [globus start script](start.globus.ubuntu22.sh) for an example.

--- a/tests/docker/irods.ubuntu22.Dockerfile
+++ b/tests/docker/irods.ubuntu22.Dockerfile
@@ -41,7 +41,7 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | sudo apt-key a
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/renci-irods.list
 
 #### Install iRODS ####
-ENV irods_version 4.3.2-0~jammy
+ENV irods_version 4.3.4-0~jammy
 
 # If testing against locally built packages, comment out the following line.
 RUN apt-get update && \

--- a/tests/globus_test.py
+++ b/tests/globus_test.py
@@ -216,7 +216,11 @@ class Globus_Test(TestCase):
                     ftp.nlst(f'/tempZone/home/user1/{filename1}')
 
                 # get the file
-                ftp.retrbinary(f'RETR /tempZone/home/user1/{filename2}', open(filename2, 'wb').write)
+                with open(filename2, 'wb') as f:
+                    def callback(data):
+                        f.write(data)
+                    ftp.retrbinary(f'RETR /tempZone/home/user1/{filename2}', callback)
+
 
             # verify that the file is unchanged
             assert_command(f'diff -q {filename1} {filename2}')
@@ -225,7 +229,7 @@ class Globus_Test(TestCase):
             os.remove(filename1)
             os.remove(filename2)
 
-            # remove file via ftp 
+            # remove file via ftp
             with FTP() as ftp:
                 ftp.connect(host='localhost', port=2811)
                 ftp.login(user='user1', passwd='pass')


### PR DESCRIPTION
1. Update the IRODS versions in both the build and tests.
2. Remove test limitation from test README as they no longer apply.
3. Update `test_file_rename_with_ftp` to make sure that the write file is closed when calling `ftp.retrbinary`.