### PR TITLE
[43] Updates required for iRODS 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 cmake_minimum_required (VERSION 3.11 FATAL_ERROR)
 
-find_package(IRODS 4.3.4 EXACT REQUIRED CONFIG)
+find_package(IRODS 5.0.0 EXACT REQUIRED CONFIG)
 set(IRODS_CLIENT_REVISION "0")
 set(IRODS_CLIENT_VERSION "${IRODS_VERSION}.${IRODS_CLIENT_REVISION}")
 
@@ -38,7 +38,6 @@ project (iRODS_DSI C CXX)
 
 set(CMAKE_CXX_STANDARD ${IRODS_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_compile_options(-nostdinc++)
 
 ##### Check ENV variables ######
 if (DEFINED ENV{GLOBUS_LOCATION})
@@ -117,7 +116,6 @@ add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter)
 remove_definitions(-DIRODS_HEADER_HPP)
 add_definitions(-DIRODS_42)
 set(irods_include_path_list
-    ${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1
     ${IRODS_INCLUDE_DIRS}
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
     ${IRODS_EXTERNALS_FULLPATH_JSON}/include
@@ -130,15 +128,12 @@ set(irods_link_obj_path
     irods_common
     irods_plugin_dependencies
     "-lrt"
-    "${IRODS_EXTERNALS_FULLPATH_AVRO}/lib/libavrocpp.so"
     "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so"
     "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_regex.so"
     "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_thread.so"
     "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so"
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
     "/${IRODS_PLUGINS_DIRECTORY}/network/libtcp_client.so"
     "/${IRODS_PLUGINS_DIRECTORY}/network/libssl_client.so"
-    "/${IRODS_PLUGINS_DIRECTORY}/auth/libnative_client.so"
     )
 
 if (CPACK_GENERATOR)

--- a/DSI/globus_gridftp_server_iRODS.cpp
+++ b/DSI/globus_gridftp_server_iRODS.cpp
@@ -829,7 +829,10 @@ iRODS_connect_and_login(
     }
 
     globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: %s connected now logging in.\n", call_context_for_logging.c_str());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     status = clientLogin(conn, nullptr, NULL);
+#pragma GCC diagnostic pop
     if (status != 0) {
         globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: %s logging in failed with error %d.\n", call_context_for_logging.c_str(), status);
         result = globus_l_gfs_iRODS_make_error("\'clientLogin\' failed.", status);

--- a/DSI/libirodsmap.c
+++ b/DSI/libirodsmap.c
@@ -40,7 +40,10 @@ int libirodsmap_connect(rcComm_t ** rcComm_out) {
     };
     libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_connect: connected to iRODS server (%s:%d)\n", myRodsEnv.rodsHost, myRodsEnv.rodsPort);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     rc = clientLogin(rcComm, NULL, NULL);
+#pragma GCC diagnostic pop
     if (rc != 0) {
         libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_connect: clientLogin failed: %s%d\n", "", rc);
         goto connect_error;

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -11,19 +11,19 @@ To run the tests, first make sure you have the code that is to be tested checked
 Build the Docker images by executing the following in this directory:
 
 ```
-docker-compose build
+docker compose build
 ```
 
 Then run one or more of the following to execute the test on the Globus server of your choice.
 
 ``` 
-docker-compose run globus-ubuntu20
-docker-compose run globus-ubuntu22
-docker-compose run globus-ubuntu24
-docker-compose run globus-el8
-docker-compose run globus-el9
-docker-compose run globus-debian11
-docker-compose run globus-debian12
+docker compose run globus-ubuntu20
+docker compose run globus-ubuntu22
+docker compose run globus-ubuntu24
+docker compose run globus-el8
+docker compose run globus-el9
+docker compose run globus-debian11
+docker compose run globus-debian12
 ```
 Running Tests Against Unreleased Versions of iRODS
 --------------------------------------------------
@@ -33,7 +33,7 @@ To run the tests against unreleased versions of iRODS, first the iRODS packages 
 After this is done, make the changes to the following files to use these built packages:
 
 1. Update `docker-compose.yml` and uncomment the `/local/path/to/<os>/packages:/irods_packages` lines.  For the iRODS server entry, you will also need to uncomment the `volumes:` line.
-2. For each of the `globus.<os>.Dockerfile` files for the platforms that are to be tested, comment out the lines that install the irods-icommands and irods-dev(el) packages.
+2. For each of the `globus.<os>.Dockerfile` files for the platforms that are to be tested, remove the lines that install the irods-icommands and irods-dev(el) packages.
 3. Uncomment the installation line in the `install_local_irods_client_packages_<os>.sh` files for the platforms that are to be tested. Update the version number in the deb and rpm package filenames as necessary.
 4. Update `irods.ubuntu22.Dockerfile` and comment out the line that installs the iRODS packages from the iRODS repo.
 5. Update `start.irods.ubuntu22.sh` and uncomment the line that installs the locally built iRODS packages.  Update version number as necessary.

--- a/tests/docker/install_local_irods_client_packages_debian12.sh
+++ b/tests/docker/install_local_irods_client_packages_debian12.sh
@@ -1,2 +1,2 @@
 # To test unreleased versions of iRODS, build the iRODS packages, uncomment the following line, and update the version as necessary.
-#apt-get update && apt-get install -y /irods_packages/irods-dev_4.3.3-0~bookworm_amd64.deb /irods_packages/irods-icommands_4.3.3-0~bookworm_amd64.deb /irods_packages/irods-runtime_4.3.3-0~bookworm_amd64.deb
+#apt-get update && apt-get install -y /irods_packages/irods-dev_5.0.0-0~bookworm_amd64.deb /irods_packages/irods-icommands_5.0.0-0~bookworm_amd64.deb /irods_packages/irods-runtime_5.0.0-0~bookworm_amd64.deb

--- a/tests/docker/install_local_irods_client_packages_el9.sh
+++ b/tests/docker/install_local_irods_client_packages_el9.sh
@@ -1,2 +1,2 @@
 # To test unreleased versions of iRODS, build the iRODS packages, uncomment the following line, and update the version as necessary.
-#dnf -y --nogpgcheck install /irods_packages/irods-devel-4.3.3-0.el9.x86_64.rpm /irods_packages/irods-icommands-4.3.3-0.el9.x86_64.rpm /irods_packages/irods-runtime-4.3.3-0.el9.x86_64.rpm
+#dnf -y --nogpgcheck install /irods_packages/irods-devel-5.0.0-0.el9.x86_64.rpm /irods_packages/irods-icommands-5.0.0-0.el9.x86_64.rpm /irods_packages/irods-runtime-5.0.0-0.el9.x86_64.rpm

--- a/tests/docker/install_local_irods_client_packages_ubuntu22.sh
+++ b/tests/docker/install_local_irods_client_packages_ubuntu22.sh
@@ -1,2 +1,2 @@
 # To test unreleased versions of iRODS, build the iRODS packages, uncomment the following line, and update the version as necessary.
-#apt-get update && apt-get install -y /irods_packages/irods-dev_4.3.3-0~jammy_amd64.deb /irods_packages/irods-runtime_4.3.3-0~jammy_amd64.deb /irods_packages/irods-icommands_4.3.3-0~jammy_amd64.deb
+#apt-get update && apt-get install -y /irods_packages/irods-dev_5.0.0-0~jammy_amd64.deb /irods_packages/irods-runtime_5.0.0-0~jammy_amd64.deb /irods_packages/irods-icommands_5.0.0-0~jammy_amd64.deb

--- a/tests/docker/install_local_irods_client_packages_ubuntu24.sh
+++ b/tests/docker/install_local_irods_client_packages_ubuntu24.sh
@@ -1,2 +1,2 @@
 # To test unreleased versions of iRODS, build the iRODS packages, uncomment the following line, and update the version as necessary.
-#apt-get update && apt-get install -y /irods_packages/irods-dev_4.3.3-0~noble_amd64.deb /irods_packages/irods-icommands_4.3.3-0~noble_amd64.deb /irods_packages/irods-runtime_4.3.3-0~noble_amd64.deb
+#apt-get update && apt-get install -y /irods_packages/irods-dev_5.0.0-0~noble_amd64.deb /irods_packages/irods-icommands_5.0.0-0~noble_amd64.deb /irods_packages/irods-runtime_5.0.0-0~noble_amd64.deb

--- a/tests/docker/irods.ubuntu22.Dockerfile
+++ b/tests/docker/irods.ubuntu22.Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
     python3-requests \
     python3-pip \
     python3-pyodbc \
+    netcat \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
@@ -41,7 +42,7 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | sudo apt-key a
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/renci-irods.list
 
 #### Install iRODS ####
-ENV irods_version 4.3.4-0~jammy
+ENV irods_version 5.0.0-0~jammy
 
 # If testing against locally built packages, comment out the following line.
 RUN apt-get update && \

--- a/tests/docker/start.irods.ubuntu22.sh
+++ b/tests/docker/start.irods.ubuntu22.sh
@@ -1,7 +1,12 @@
 #! /bin/bash
 
+send_irods_heartbeat() {
+    response=$(echo -e "\x00\x00\x00\x33<MsgHeader_PI><type>HEARTBEAT</type></MsgHeader_PI>" | netcat 127.0.0.1 1247)
+}
+
+
 # If testing against locally built packages, uncomment the following line and adjust the version number in the deb files as necessary.
-#apt-get update && apt-get install -y /irods_packages/irods-database-plugin-postgres_4.3.3-0~jammy_amd64.deb /irods_packages/irods-icommands_4.3.3-0~jammy_amd64.deb /irods_packages/irods-runtime_4.3.3-0~jammy_amd64.deb /irods_packages/irods-server_4.3.3-0~jammy_amd64.deb
+#apt-get update && apt-get install -y /irods_packages/irods-database-plugin-postgres_5.0.0-0~jammy_amd64.deb /irods_packages/irods-icommands_5.0.0-0~jammy_amd64.deb /irods_packages/irods-runtime_5.0.0-0~jammy_amd64.deb /irods_packages/irods-server_5.0.0-0~jammy_amd64.deb
 
 # Start the Postgres database.
 service postgresql start
@@ -17,7 +22,15 @@ echo Postgres took approximately $counter seconds to fully start ...
 /var/lib/irods/scripts/setup_irods.py < /var/lib/irods/packaging/localhost_setup_postgres.input
 
 #### Start iRODS ####
-service irods start
+sudo -H -u irods -g irods bash -c "irodsServer -d"
+
+# make sure iRODS is done starting up or the commands below will fail
+send_irods_heartbeat
+while [[ "$response" != "HEARTBEAT" ]]; do
+    sleep 1
+    send_irods_heartbeat
+done
+
 
 #### Create user1 in iRODS ####
 sudo -H -u irods -g irods bash -c "iadmin mkuser user1 rodsuser"


### PR DESCRIPTION
- Changes to CMakeLists.txt to conform to new build requirements.
- Update references from 4.3.x to 5.0.0.
- Update how iRODS is started and added heartbeat check before continuing.
- A couple of minor updates to README.
- Update code to ignore deprecation error when calling clientLogin().

All tests passed.