### PR TITLE
[140] Restore local hashers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,15 @@ set(IRODS_MINIMUM_VERSION "4.90.0")
 set(IRODS_MAXIMUM_VERSION "6.0.0")
 find_package(IRODS "${IRODS_MINIMUM_VERSION}...<${IRODS_MAXIMUM_VERSION}" REQUIRED)
 
+# The iRODS-provided hasher for sha512 is broken in iRODS 5.0.2.
+# Only use the iRODS hashers for releases greater than 5.0.2.
+# Otherwise, use the locally provided hashers.
+if (IRODS_VERSION VERSION_LESS_EQUAL "5.0.2")
+	set(USE_LOCAL_HASHERS TRUE)
+else()
+	set(USE_LOCAL_HASHERS FALSE)
+endif()
+
 include(RequireOutOfSourceBuild)
 
 set(IRODS_CLIENT_NAME "irods-gridftp-client")
@@ -71,6 +80,11 @@ include(ObjectTargetHelpers)
 find_package(CURL REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(fmt 8.1.1 REQUIRED)
+
+if (USE_LOCAL_HASHERS)
+	find_package(OpenSSL REQUIRED COMPONENTS Crypto)
+endif()
+
 find_package(
 	Globus
 	REQUIRED
@@ -145,9 +159,20 @@ elseif (CURL_LIBRARY_REALNAME STREQUAL "libcurl-nss")
 elseif (CURL_LIBRARY_REALNAME STREQUAL "libcurl")
 	set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libcurl4")
 endif()
+if (USE_LOCAL_HASHERS)
+	if (OPENSSL_VERSION VERSION_LESS "3.0.0")
+		set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libssl1.1")
+	else()
+		set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libssl3")
+	endif()
+endif()
 
 set(CPACK_RPM_PACKAGE_NAME ${IRODS_CLIENT_NAME})
-set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, (libcurl or libcurl-minimum)")
+if (USE_LOCAL_HASHERS)
+	set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, (libcurl or libcurl-minimum), openssl")
+else()
+	set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, (libcurl or libcurl-minimum)")
+endif()
 
 if (NOT CPACK_GENERATOR)
 	set(CPACK_GENERATOR ${IRODS_CPACK_GENERATOR} CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,11 @@
 add_subdirectory(pid_manager)
 add_subdirectory(irodsmap)
+
+# The iRODS-provided hasher for sha512 is broken in iRODS 5.0.2.
+# Only use the iRODS hashers for releases greater than 5.0.2.
+# Otherwise, use the locally provided hashers.
+if (USE_LOCAL_HASHERS)
+	add_subdirectory(globus_hasher)
+endif()
 add_subdirectory(gridmap_callout)
 add_subdirectory(irods_dsi)

--- a/lib/globus_hasher/CMakeLists.txt
+++ b/lib/globus_hasher/CMakeLists.txt
@@ -1,0 +1,50 @@
+add_library(
+	irods_globus_hasher
+	OBJECT
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/ADLER32Strategy.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/Hasher.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/MD5Strategy.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/SHA1Strategy.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/SHA256Strategy.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/SHA512Strategy.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/irods_hasher_factory.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/ADLER32Strategy.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/Hasher.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/HashStrategy.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/MD5Strategy.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/SHA1Strategy.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/SHA256Strategy.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/SHA512Strategy.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/checksum.hpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/irods_hasher_factory.hpp"
+)
+objects_link_libraries(
+	irods_globus_hasher
+	PUBLIC
+	irods_common
+	PRIVATE
+	OpenSSL::Crypto
+)
+target_include_directories(
+	irods_globus_hasher
+	PUBLIC
+	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+)
+target_include_directories(
+	irods_globus_hasher
+	PRIVATE
+	${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+)
+target_compile_definitions(
+	irods_globus_hasher
+	PRIVATE
+	${IRODS_COMPILE_DEFINITIONS}
+	${IRODS_COMPILE_DEFINITIONS_PRIVATE}
+	OPENSSL_API_COMPAT=10100
+)
+set_target_properties(
+	irods_globus_hasher
+	PROPERTIES
+	INTERFACE_POSITION_INDEPENDENT_CODE TRUE
+	POSITION_INDEPENDENT_CODE TRUE
+)

--- a/lib/globus_hasher/include/ADLER32Strategy.hpp
+++ b/lib/globus_hasher/include/ADLER32Strategy.hpp
@@ -1,0 +1,30 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_ADLER32_STRATEGY_HPP
+#define IRODS_GLOBUS_CONNECTOR_ADLER32_STRATEGY_HPP
+
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+    extern const std::string ADLER32_NAME;
+    class ADLER32Strategy : public HashStrategy {
+        public:
+            ADLER32Strategy() {};
+            virtual ~ADLER32Strategy() {};
+
+            std::string name() const override {
+                return ADLER32_NAME;
+            }
+            error init( boost::any& context ) const override;
+            error update( const std::string& data, boost::any& context ) const override;
+            error digest( std::string& messageDigest, boost::any& context ) const override;
+            bool isChecksum( const std::string& ) const override;
+
+    };
+} // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_ADLER32_STRATEGY_HPP

--- a/lib/globus_hasher/include/HashStrategy.hpp
+++ b/lib/globus_hasher/include/HashStrategy.hpp
@@ -1,0 +1,25 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_HASH_STRATEGY_HPP
+#define IRODS_GLOBUS_CONNECTOR_HASH_STRATEGY_HPP
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+
+    class HashStrategy {
+        public:
+
+            virtual ~HashStrategy() {};
+
+            virtual std::string name() const = 0;
+            virtual error init( boost::any& context ) const = 0;
+            virtual error update( const std::string&, boost::any& context ) const = 0;
+            virtual error digest( std::string& messageDigest, boost::any& context ) const = 0;
+            virtual bool isChecksum( const std::string& ) const = 0;
+    };
+} // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_HASH_STRATEGY_HPP

--- a/lib/globus_hasher/include/Hasher.hpp
+++ b/lib/globus_hasher/include/Hasher.hpp
@@ -1,0 +1,34 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_HASHER_HPP
+#define IRODS_GLOBUS_CONNECTOR_HASHER_HPP
+
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+
+    const std::string STRICT_HASH_POLICY( "strict" );
+    const std::string COMPATIBLE_HASH_POLICY( "compatible" );
+
+    class Hasher {
+        public:
+            Hasher() : _strategy( NULL ) {}
+
+            error init( const HashStrategy* );
+            error update( const std::string& );
+            error digest( std::string& messageDigest );
+
+        private:
+            const HashStrategy* _strategy;
+            boost::any          _context;
+            error               _stored_error;
+            std::string         _stored_digest;
+    };
+
+}; // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_HASHER_HPP

--- a/lib/globus_hasher/include/MD5Strategy.hpp
+++ b/lib/globus_hasher/include/MD5Strategy.hpp
@@ -1,0 +1,30 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_MD5_STRATEGY_HPP
+#define IRODS_GLOBUS_CONNECTOR_MD5_STRATEGY_HPP
+
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+    extern const std::string MD5_NAME;
+    class MD5Strategy : public HashStrategy {
+        public:
+            MD5Strategy() {};
+            virtual ~MD5Strategy() {};
+
+            std::string name() const override {
+                return MD5_NAME;
+            }
+            error init( boost::any& context ) const override;
+            error update( const std::string&, boost::any& context ) const override;
+            error digest( std::string& messageDigest, boost::any& context ) const override;
+            bool isChecksum( const std::string& ) const override;
+
+    };
+} // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_MD5_STRATEGY_HPP

--- a/lib/globus_hasher/include/SHA1Strategy.hpp
+++ b/lib/globus_hasher/include/SHA1Strategy.hpp
@@ -1,0 +1,30 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_SHA1_STRATEGY_HPP
+#define IRODS_GLOBUS_CONNECTOR_SHA1_STRATEGY_HPP
+
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+    extern const std::string SHA1_NAME;
+    class SHA1Strategy : public HashStrategy {
+        public:
+            SHA1Strategy() {};
+            virtual ~SHA1Strategy() {};
+
+            std::string name() const override {
+                return SHA1_NAME;
+            }
+            error init( boost::any& context ) const override;
+            error update( const std::string& data, boost::any& context ) const override;
+            error digest( std::string& messageDigest, boost::any& context ) const override;
+            bool isChecksum( const std::string& ) const override;
+
+    };
+} // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_SHA1_STRATEGY_HPP

--- a/lib/globus_hasher/include/SHA256Strategy.hpp
+++ b/lib/globus_hasher/include/SHA256Strategy.hpp
@@ -1,0 +1,30 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_SHA256_STRATEGY_HPP
+#define IRODS_GLOBUS_CONNECTOR_SHA256_STRATEGY_HPP
+
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+    extern const std::string SHA256_NAME;
+    class SHA256Strategy : public HashStrategy {
+        public:
+            SHA256Strategy() {};
+            virtual ~SHA256Strategy() {};
+
+            virtual std::string name() const override {
+                return SHA256_NAME;
+            }
+            error init( boost::any& context ) const override;
+            error update( const std::string& data, boost::any& context ) const override;
+            error digest( std::string& messageDigest, boost::any& context ) const override;
+            bool isChecksum( const std::string& ) const override;
+
+    };
+} // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_SHA256_STRATEGY_HPP

--- a/lib/globus_hasher/include/SHA512Strategy.hpp
+++ b/lib/globus_hasher/include/SHA512Strategy.hpp
@@ -1,0 +1,30 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_SHA512_STRATEGY_HPP
+#define IRODS_GLOBUS_CONNECTOR_SHA512_STRATEGY_HPP
+
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <string>
+
+namespace irods::globus {
+    extern const std::string SHA512_NAME;
+    class SHA512Strategy : public HashStrategy {
+        public:
+            SHA512Strategy() {};
+            virtual ~SHA512Strategy() {};
+
+            std::string name() const override {
+                return SHA512_NAME;
+            }
+            error init( boost::any& context ) const override;
+            error update( const std::string& data, boost::any& context ) const override;
+            error digest( std::string& messageDigest, boost::any& context ) const override;
+            bool isChecksum( const std::string& ) const override;
+
+    };
+} // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_SHA512_STRATEGY_HPP

--- a/lib/globus_hasher/include/checksum.hpp
+++ b/lib/globus_hasher/include/checksum.hpp
@@ -1,0 +1,27 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_CHECKSUM_HPP
+#define IRODS_GLOBUS_CONNECTOR_CHECKSUM_HPP
+
+#include <irods/objInfo.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SHA256_CHKSUM_PREFIX "sha2:"
+#define SHA512_CHKSUM_PREFIX "sha512:"
+#define ADLER32_CHKSUM_PREFIX "adler32:"
+#define SHA1_CHKSUM_PREFIX "sha1:"
+int verifyChksumLocFile( char *fileName, const char *myChksum, char *chksumStr );
+
+int
+chksumLocFile( const char *fileName, char *chksumStr, const char* );
+int
+hashToStr( unsigned char *digest, char *digestStr );
+int
+rcChksumLocFile( char *fileName, char *chksumFlag, keyValPair_t *condInput, const char* );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* IRODS_GLOBUS_CONNECTOR_CHECKSUM_HPP */

--- a/lib/globus_hasher/include/irods_hasher_factory.hpp
+++ b/lib/globus_hasher/include/irods_hasher_factory.hpp
@@ -1,0 +1,19 @@
+#ifndef IRODS_GLOBUS_CONNECTOR_HASHER_FACTORY_HPP
+#define IRODS_GLOBUS_CONNECTOR_HASHER_FACTORY_HPP
+
+#include "Hasher.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <string>
+
+namespace irods::globus {
+
+    error getHasher( const std::string& name, Hasher& hasher );
+    error get_hash_scheme_from_checksum(
+        const std::string& checksum,
+        std::string& scheme );
+
+}; // namespace irods::globus
+
+#endif // IRODS_GLOBUS_CONNECTOR_HASHER_FACTORY_HPP

--- a/lib/globus_hasher/src/ADLER32Strategy.cpp
+++ b/lib/globus_hasher/src/ADLER32Strategy.cpp
@@ -1,0 +1,83 @@
+#include "ADLER32Strategy.hpp"
+#include "checksum.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/any.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace irods::globus {
+
+    const std::string ADLER32_NAME( "adler32" );
+
+    struct adler32_parts {
+        uint32_t a;
+        uint32_t b;
+    };
+
+    adler32_parts adler32_init() {
+        return adler32_parts{1, 0};
+    }
+
+    static adler32_parts adler32_update(const adler32_parts& parts, const unsigned char *data, size_t len) {
+
+        const uint32_t MOD_ADLER = 65521;
+
+        uint32_t a = parts.a, b = parts.b;
+
+        // Process each byte of the data in order
+        for (size_t index = 0; index < len; ++index)
+        {
+            a = (a + data[index]) % MOD_ADLER;
+            b = (b + a) % MOD_ADLER;
+        }
+
+        return adler32_parts{a, b};
+    }
+
+    static uint32_t adler32_final(const adler32_parts& parts) {
+        return (parts.b << 16) | parts.a;
+    }
+
+
+    error
+    ADLER32Strategy::init( boost::any& _context ) const {
+        _context = adler32_init();
+        return SUCCESS();
+    }
+
+    error
+    ADLER32Strategy::update( const std::string& data, boost::any& _context ) const {
+
+        _context = adler32_update(boost::any_cast<adler32_parts>(_context), reinterpret_cast<const unsigned char*>(data.c_str()), data.size());
+        return SUCCESS();
+    }
+
+    error
+    ADLER32Strategy::digest( std::string& _messageDigest, boost::any& _context ) const {
+
+        const unsigned int ADLER32_DIGEST_LENGTH = 4;
+
+        uint32_t result = adler32_final(boost::any_cast<adler32_parts>(_context));
+
+        std::stringstream ss;
+        ss << std::setfill('0') << std::hex << std::setw(ADLER32_DIGEST_LENGTH * 2) << result;
+
+        _messageDigest = ADLER32_CHKSUM_PREFIX;
+        _messageDigest += ss.str();
+
+        return SUCCESS();
+    }
+
+    bool
+    ADLER32Strategy::isChecksum( const std::string& _chksum ) const {
+        return boost::starts_with( _chksum, ADLER32_CHKSUM_PREFIX );
+    }
+}; // namespace irods::globus

--- a/lib/globus_hasher/src/Hasher.cpp
+++ b/lib/globus_hasher/src/Hasher.cpp
@@ -1,0 +1,48 @@
+#include "Hasher.hpp"
+#include "HashStrategy.hpp"
+
+#include <irods/irods_error.hpp>
+#include <irods/rodsErrorTable.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include <string>
+
+namespace irods::globus {
+
+    error
+    Hasher::init( const HashStrategy* _strategy_in ) {
+        _strategy = _strategy_in;
+        _stored_error = SUCCESS();
+        _stored_digest.clear();
+
+        return PASS( _strategy->init( _context ) );
+    }
+
+    error
+    Hasher::update( const std::string& _data ) {
+        if ( NULL == _strategy ) {
+            return ERROR( SYS_UNINITIALIZED, "Update called on a hasher that has not been initialized" );
+        }
+        if ( !_stored_digest.empty() ) {
+            return ERROR( SYS_HASH_IMMUTABLE, "Update called on a hasher that has already generated a digest" );
+        }
+        error ret = _strategy->update( _data, _context );
+
+        return PASS( ret );
+    }
+
+    error
+    Hasher::digest( std::string& _messageDigest ) {
+        if ( NULL == _strategy ) {
+            return ERROR( SYS_UNINITIALIZED, "Digest called on a hasher that has not been initialized" );
+        }
+        if ( _stored_digest.empty() ) {
+            _stored_error = _strategy->digest( _stored_digest, _context );
+        }
+
+        _messageDigest = _stored_digest;
+        return PASS( _stored_error );
+    }
+
+}; //namespace irods::globus

--- a/lib/globus_hasher/src/MD5Strategy.cpp
+++ b/lib/globus_hasher/src/MD5Strategy.cpp
@@ -1,0 +1,47 @@
+#include "MD5Strategy.hpp"
+
+#include <irods/irods_error.hpp>
+
+#include <boost/any.hpp>
+
+#include <openssl/md5.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace irods::globus {
+
+    const std::string MD5_NAME( "md5" );
+
+    error
+    MD5Strategy::init( boost::any& _context ) const {
+        _context = MD5_CTX();
+        MD5_Init( boost::any_cast<MD5_CTX>( &_context ) );
+        return SUCCESS();
+    }
+
+    error
+    MD5Strategy::update( const std::string& data, boost::any& _context ) const {
+        MD5_Update( boost::any_cast<MD5_CTX>( &_context ), ( const unsigned char * )data.c_str(), data.size() );
+        return SUCCESS();
+    }
+
+    error
+    MD5Strategy::digest( std::string& messageDigest, boost::any& _context ) const {
+        unsigned char buffer[17];
+        MD5_Final( buffer, boost::any_cast<MD5_CTX>( &_context ) );
+        std::stringstream ins;
+        for ( int i = 0; i < 16; ++i ) {
+            ins << std::setfill( '0' ) << std::setw( 2 ) << std::hex << ( int )buffer[i];
+        }
+        messageDigest = ins.str();
+        return SUCCESS();
+    }
+
+    bool
+    MD5Strategy::isChecksum( const std::string& _chksum ) const {
+        return std::string::npos == _chksum.find_first_not_of( "0123456789abcdefABCDEF" );
+    }
+}; //namespace irods::globus

--- a/lib/globus_hasher/src/SHA1Strategy.cpp
+++ b/lib/globus_hasher/src/SHA1Strategy.cpp
@@ -1,0 +1,52 @@
+#include "SHA1Strategy.hpp"
+#include "checksum.hpp"
+
+#include <irods/base64.hpp>
+#include <irods/irods_error.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/any.hpp>
+
+#include <openssl/sha.h>
+
+#include <cstring>
+#include <string>
+
+namespace irods::globus {
+
+    const std::string SHA1_NAME( "sha1" );
+
+    error
+    SHA1Strategy::init( boost::any& _context ) const {
+        _context = SHA_CTX();
+        SHA1_Init( boost::any_cast<SHA_CTX>( &_context ) );
+        return SUCCESS();
+    }
+
+    error
+    SHA1Strategy::update( const std::string& data, boost::any& _context ) const {
+        SHA1_Update( boost::any_cast<SHA_CTX>( &_context ), data.c_str(), data.size() );
+        return SUCCESS();
+    }
+
+    error
+    SHA1Strategy::digest( std::string& _messageDigest, boost::any& _context ) const {
+        unsigned char final_buffer[SHA_DIGEST_LENGTH];
+        SHA1_Final( final_buffer, boost::any_cast<SHA_CTX>( &_context ) );
+        int len = strlen( SHA1_CHKSUM_PREFIX );
+        unsigned long out_len = CHKSUM_LEN - len;
+
+        unsigned char out_buffer[CHKSUM_LEN];
+        irods::base64_encode( final_buffer, SHA_DIGEST_LENGTH, out_buffer, &out_len );
+
+        _messageDigest = SHA1_CHKSUM_PREFIX;
+        _messageDigest += std::string( ( char* )out_buffer, out_len );
+
+        return SUCCESS();
+    }
+
+    bool
+    SHA1Strategy::isChecksum( const std::string& _chksum ) const {
+        return boost::starts_with( _chksum, SHA1_CHKSUM_PREFIX );
+    }
+}; // namespace irods::globus

--- a/lib/globus_hasher/src/SHA256Strategy.cpp
+++ b/lib/globus_hasher/src/SHA256Strategy.cpp
@@ -1,0 +1,52 @@
+#include "SHA256Strategy.hpp"
+#include "checksum.hpp"
+
+#include <irods/base64.hpp>
+#include <irods/irods_error.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/any.hpp>
+
+#include <openssl/sha.h>
+
+#include <cstring>
+#include <string>
+
+namespace irods::globus {
+
+    const std::string SHA256_NAME( "sha256" );
+
+    error
+    SHA256Strategy::init( boost::any& _context ) const {
+        _context = SHA256_CTX();
+        SHA256_Init( boost::any_cast<SHA256_CTX>( &_context ) );
+        return SUCCESS();
+    }
+
+    error
+    SHA256Strategy::update( const std::string& data, boost::any& _context ) const {
+        SHA256_Update( boost::any_cast<SHA256_CTX>( &_context ), data.c_str(), data.size() );
+        return SUCCESS();
+    }
+
+    error
+    SHA256Strategy::digest( std::string& _messageDigest, boost::any& _context ) const {
+        unsigned char final_buffer[SHA256_DIGEST_LENGTH];
+        SHA256_Final( final_buffer, boost::any_cast<SHA256_CTX>( &_context ) );
+        int len = strlen( SHA256_CHKSUM_PREFIX );
+        unsigned long out_len = CHKSUM_LEN - len;
+
+        unsigned char out_buffer[CHKSUM_LEN];
+        irods::base64_encode( final_buffer, SHA256_DIGEST_LENGTH, out_buffer, &out_len );
+
+        _messageDigest = SHA256_CHKSUM_PREFIX;
+        _messageDigest += std::string( ( char* )out_buffer, out_len );
+
+        return SUCCESS();
+    }
+
+    bool
+    SHA256Strategy::isChecksum( const std::string& _chksum ) const {
+        return boost::starts_with( _chksum, SHA256_CHKSUM_PREFIX );
+    }
+}; // namespace irods::globus

--- a/lib/globus_hasher/src/SHA512Strategy.cpp
+++ b/lib/globus_hasher/src/SHA512Strategy.cpp
@@ -1,0 +1,52 @@
+#include "SHA512Strategy.hpp"
+#include "checksum.hpp"
+
+#include <irods/base64.hpp>
+#include <irods/irods_error.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/any.hpp>
+
+#include <openssl/sha.h>
+
+#include <cstring>
+#include <string>
+
+namespace irods::globus {
+
+    const std::string SHA512_NAME( "sha512" );
+
+    error
+    SHA512Strategy::init( boost::any& _context ) const {
+        _context = SHA512_CTX();
+        SHA512_Init( boost::any_cast<SHA512_CTX>( &_context ) );
+        return SUCCESS();
+    }
+
+    error
+    SHA512Strategy::update( const std::string& data, boost::any& _context ) const {
+        SHA512_Update( boost::any_cast<SHA512_CTX>( &_context ), data.c_str(), data.size() );
+        return SUCCESS();
+    }
+
+    error
+    SHA512Strategy::digest( std::string& _messageDigest, boost::any& _context ) const {
+        unsigned char final_buffer[SHA512_DIGEST_LENGTH];
+        SHA512_Final( final_buffer, boost::any_cast<SHA512_CTX>( &_context ) );
+        int len = strlen( SHA512_CHKSUM_PREFIX );
+        unsigned long out_len = CHKSUM_LEN * 2 - len;
+
+        unsigned char out_buffer[CHKSUM_LEN * 2];
+        irods::base64_encode( final_buffer, SHA512_DIGEST_LENGTH, out_buffer, &out_len );
+
+        _messageDigest = SHA512_CHKSUM_PREFIX;
+        _messageDigest += std::string( ( char* )out_buffer, out_len );
+
+        return SUCCESS();
+    }
+
+    bool
+    SHA512Strategy::isChecksum( const std::string& _chksum ) const {
+        return boost::starts_with( _chksum, SHA512_CHKSUM_PREFIX );
+    }
+}; // namespace irods::globus

--- a/lib/globus_hasher/src/irods_hasher_factory.cpp
+++ b/lib/globus_hasher/src/irods_hasher_factory.cpp
@@ -1,0 +1,79 @@
+#include "irods_hasher_factory.hpp"
+#include "checksum.hpp"
+#include "HashStrategy.hpp"
+#include "Hasher.hpp"
+#include "MD5Strategy.hpp"
+#include "SHA256Strategy.hpp"
+#include "SHA512Strategy.hpp"
+#include "ADLER32Strategy.hpp"
+#include "SHA1Strategy.hpp"
+
+#include <irods/irods_error.hpp>
+#include <irods/rodsErrorTable.h>
+
+#include <boost/unordered_map.hpp>
+
+#include <sstream>
+#include <string>
+
+namespace irods::globus {
+
+    namespace {
+        const SHA256Strategy _sha256;
+        const SHA512Strategy _sha512;
+        const ADLER32Strategy _adler32;
+        const MD5Strategy _md5;
+        const SHA1Strategy _sha1;
+
+        auto make_map() {
+            boost::unordered_map<const std::string, const HashStrategy*> map;
+            map[ SHA256_NAME ] = &_sha256;
+            map[ SHA512_NAME ] = &_sha512;
+            map[ MD5_NAME ] = &_md5;
+            map[ ADLER32_NAME ] = &_adler32;
+            map[ SHA1_NAME ] = &_sha1;
+            return map;
+        }
+
+    };
+
+    error
+    getHasher( const std::string& _name, Hasher& _hasher ) {
+
+        const auto _strategies{ make_map() };
+
+        auto it = _strategies.find( _name );
+        if ( _strategies.end() == it ) {
+            std::stringstream msg;
+            msg << "Unknown hashing scheme [" << _name << "]";
+            return ERROR( SYS_INVALID_INPUT_PARAM, msg.str() );
+        }
+        _hasher.init( it->second );
+        return SUCCESS();
+    }
+
+    error
+    get_hash_scheme_from_checksum(
+        const std::string& _chksum,
+        std::string&       _scheme ) {
+
+        const auto _strategies{ make_map() };
+
+        if ( _chksum.empty() ) {
+            return ERROR(
+                       SYS_INVALID_INPUT_PARAM,
+                       "empty chksum string" );
+        }
+        for ( const auto& [key, strategy] : _strategies) {
+            if ( strategy->isChecksum( _chksum ) ) {
+                _scheme = strategy->name();
+                return SUCCESS();
+            }
+        }
+        return ERROR(
+                   SYS_INVALID_INPUT_PARAM,
+                   "hash scheme not found" );
+
+    } // get_hasher_scheme_from_checksum
+
+}; // namespace irods::globus

--- a/lib/irods_dsi/CMakeLists.txt
+++ b/lib/irods_dsi/CMakeLists.txt
@@ -29,6 +29,17 @@ target_link_objects(
 	PRIVATE
 	irods_globus_pid_manager
 )
+
+# The iRODS-provided hasher for sha512 is broken in iRODS 5.0.2.
+# Only use the iRODS hashers for releases greater than 5.0.2.
+# Otherwise, use the locally provided hashers.
+if (USE_LOCAL_HASHERS)
+	target_link_objects(
+		globus_gridftp_server_iRODS
+		PRIVATE
+		irods_globus_hasher
+	)
+endif()
 target_include_directories(
 	globus_gridftp_server_iRODS
 	PRIVATE

--- a/lib/irods_dsi/src/globus_gridftp_server_iRODS.cpp
+++ b/lib/irods_dsi/src/globus_gridftp_server_iRODS.cpp
@@ -27,6 +27,21 @@
 #include "circular_buffer.hpp"
 #include "pid_manager.h"
 
+// irods version (needed to select the hasher implementation below)
+#include <irods/irods_version.h>
+
+// The iRODS-provided hasher for sha512 is broken in iRODS 5.0.2.
+// Only use the iRODS hashers for releases greater than 5.0.2.
+// Otherwise, use the locally provided hashers.
+#if IRODS_VERSION_INTEGER > 5000002
+#  include <irods/irods_hasher_factory.hpp>
+namespace irods_hasher_ns = irods;
+#else
+#  include "Hasher.hpp"
+#  include "irods_hasher_factory.hpp"
+namespace irods_hasher_ns = irods::globus;
+#endif
+
 // irods includes
 #include <irods/base64.hpp>
 #include <irods/collCreate.h>
@@ -43,7 +58,6 @@
 #include <irods/getRodsEnv.h>
 #include <irods/irods_at_scope_exit.hpp>
 #include <irods/irods_error.hpp>
-#include <irods/irods_hasher_factory.hpp>
 #include <irods/irods_query.hpp>
 #include <irods/irods_string_tokenize.hpp>
 #include <irods/irods_virtual_path.hpp>
@@ -1671,10 +1685,10 @@ globus_l_gfs_iRODS_command(
                }
 
                // get the hasher
-               irods::Hasher hasher;
+               irods_hasher_ns::Hasher hasher;
                std::string checksum_algorithm_lower(cmd_info->cksm_alg);
                boost::to_lower(checksum_algorithm_lower);
-               irods::error ret = irods::getHasher(
+               irods::error ret = irods_hasher_ns::getHasher(
                                       checksum_algorithm_lower.c_str(),
                                       hasher );
                if ( !ret.ok() ) {


### PR DESCRIPTION
Use local hashers if iRODS version <= 5.0.2

I tested this for both 5.0.2 and 5.0.90.

I am not sure I did the cmake changes exactly as @SwooshyCueb wanted it.  I forgot to save the notes I made.  So please take a look.